### PR TITLE
Split base block

### DIFF
--- a/prep-sys.sh
+++ b/prep-sys.sh
@@ -2,4 +2,4 @@
 # Install fundamental packages before starting computing node installation
 set -o xtrace
 
-apt install git make
+apt install git make ntp tmux lm-sensors g++ libgmp-dev


### PR DESCRIPTION
Splitting out the base block to a script to allow diverse systems to be prepared.
This script installs basic software pieces to allow gpuOwl compilation and running under ROCm, amdgpu-pro and Nvidia-driver.